### PR TITLE
Add Amazon Linux 2016.09 and 2017.03 platforms

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,5 +1,6 @@
 driver:
-  name: vagrant
+  name: docker
+  use_sudo: false
 
 provisioner:
   name: ansible_playbook
@@ -15,88 +16,91 @@ verifier:
 
 platforms:
   - name: centos-6
-    driver:
-      box: centos/6
+    driver_config:
+      image: centos:6
+      platform: centos
   - name: centos-7
-    driver:
-      box: centos/7
+    driver_config:
+      image: centos:7
+      platform: centos
   - name: fedora-23
-    driver:
-      box: fedora/23-cloud-base
-# Due to a bug in kitchen-ansible, statically set the ansible_platform to Amazon
-# See: https://github.com/neillturner/kitchen-ansible/issues/216
+    driver_config:
+      image: fedora:23
+      platform: rhel
+  - name: debian-7
+    driver_config:
+      image: debian:7
+      platform: rhel
+    provisioner:
+      require_ansible_omnibus: true
+      require_ansible_repo: false
+  - name: debian-8
+    driver_config:
+      image: debian:8
+      platform: rhel
+    provisioner:
+      require_ansible_omnibus: true
+      require_ansible_repo: false
+  - name: ubuntu-12.04
+    driver_config:
+      image: ubuntu:12.04
+      platform: ubuntu
+    provisioner:
+      require_ansible_omnibus: true
+      require_ansible_repo: false
+    verifier:
+      ruby_bindir: '/opt/chef/embedded/bin'
+  - name: ubuntu-15.04
+    driver_config:
+      image: ubuntu:15.04
+      platform: ubuntu
+  - name: ubuntu-15.10
+    driver_config:
+      image: ubuntu:15.10
+      platform: ubuntu
+  - name: ubuntu-16.04
+    driver_config:
+      image: ubuntu:16.04
+      platform: ubuntu
   - name: amazonlinux-2016.03
-    driver:
-      name: ec2
-      image_id: ami-7172b611
-      aws_ssh_key_id: test-kitchen
-      region: us-west-2
-      availability_zone: a
-      instance_type: t2.large
-      associate_public_ip: true
-      interface: dns
-    transport:
-      username: ec2-user
-      ssh_key: ~/.ssh/id_rsa
+    driver_config:
+      image: librato/agent_amazon_2016.03
+      platform: centos
+      remove_images: true
     provisioner:
       ansible_platform: 'amazon'
+      ansible_distribution: 'Amazon'
+      ansible_distribution_version: '2016.03'
       require_chef_for_busser: true
       require_ruby_for_busser: false
     verifier:
       ruby_bindir: '/opt/chef/embedded/bin'
   - name: amazonlinux-2016.09
-    driver:
-      name: ec2
-      image_id: ami-5ec1673e
-      aws_ssh_key_id: test-kitchen
-      region: us-west-2
-      availability_zone: a
-      instance_type: t2.large
-      associate_public_ip: true
-      interface: dns
-    transport:
-      username: ec2-user
-      ssh_key: ~/.ssh/id_rsa
+    driver_config:
+      image: librato/agent_amazon_2016.09
+      platform: centos
+      remove_images: true
     provisioner:
       ansible_platform: 'amazon'
+      ansible_distribution: 'Amazon'
+      ansible_distribution_version: '2016.09'
       require_chef_for_busser: true
       require_ruby_for_busser: false
     verifier:
       ruby_bindir: '/opt/chef/embedded/bin'
-# Ansible doesn't provide Debian repos so we use the omnibus installer to provide Ansible
-  - name: debian-7
-    driver:
-      box: debian/wheezy64
+  - name: amazonlinux-2017.03
+    driver_config:
+      image: librato/agent_amazon_2017.03
+      platform: centos
+      remove_images: true
     provisioner:
-      require_ansible_omnibus: true
-      require_ansible_repo: false
-  - name: debian-8
-    driver:
-      box: debian/jessie64
-    provisioner:
-      require_ansible_omnibus: true
-      require_ansible_repo: false
-# Ubuntu 12.04 uses Ruby 1.8.7 while busser requires Ruby 1.9+, so we need to use Chef to run busser
-  - name: ubuntu-12.04
-    driver:
-      box: ubuntu/precise64
-    provisioner:
+      ansible_platform: 'amazon'
+      ansible_distribution: 'Amazon'
+      ansible_distribution_version: '2017.03'
       require_chef_for_busser: true
       require_ruby_for_busser: false
     verifier:
       ruby_bindir: '/opt/chef/embedded/bin'
-  - name: ubuntu-14.04
-    driver:
-      box: ubuntu/trusty64
-  - name: ubuntu-15.04
-    driver:
-      box: larryli/vivid64
-  - name: ubuntu-15.10
-    driver:
-      box: ubuntu/wily64
-  - name: ubuntu-16.04
-    driver:
-      box: ubuntu/xenial64
 
 suites:
   - name: default

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,11 +1,15 @@
 driver:
   name: docker
   use_sudo: false
+  privileged: true
+  driver_config:
+    ssl_verify_mode: ":verify_none"
 
 provisioner:
   name: ansible_playbook
   require_ansible_repo: true
   ansible_verbose: true
+  ansible_verbosity: 2
   require_chef_for_busser: false
   require_ruby_for_busser: true
   hosts: hosts
@@ -14,19 +18,26 @@ provisioner:
 verifier:
   ruby_bindir: '/usr/bin'
 
+transport:
+  name: ssh
+  connection_timeout: 60
+
 platforms:
   - name: centos-6
     driver_config:
       image: centos:6
       platform: centos
+
   - name: centos-7
     driver_config:
       image: centos:7
       platform: centos
+
   - name: fedora-23
     driver_config:
       image: fedora:23
       platform: rhel
+
   - name: debian-7
     driver_config:
       image: debian:7
@@ -34,6 +45,7 @@ platforms:
     provisioner:
       require_ansible_omnibus: true
       require_ansible_repo: false
+
   - name: debian-8
     driver_config:
       image: debian:8
@@ -41,6 +53,7 @@ platforms:
     provisioner:
       require_ansible_omnibus: true
       require_ansible_repo: false
+
   - name: ubuntu-12.04
     driver_config:
       image: ubuntu:12.04
@@ -50,23 +63,27 @@ platforms:
       require_ansible_repo: false
     verifier:
       ruby_bindir: '/opt/chef/embedded/bin'
+
   - name: ubuntu-15.04
     driver_config:
       image: ubuntu:15.04
       platform: ubuntu
+
   - name: ubuntu-15.10
     driver_config:
       image: ubuntu:15.10
       platform: ubuntu
+
   - name: ubuntu-16.04
     driver_config:
       image: ubuntu:16.04
       platform: ubuntu
+
   - name: amazonlinux-2016.03
     driver_config:
       image: librato/agent_amazon_2016.03
-      platform: centos
-      remove_images: true
+      platform: rhel
+      provision_command: sed -i'' 's/releasever=latest/# releasever=latest/' /etc/yum.conf && yum -y reinstall glibc-common &&  yum -y remove ca-certificates && yum -y install ca-certificates && yum -y update ca-certificates && yum -y update && yum -y --skip-broke groupinstall "Development Tools" && yum -y install epel-release yum-utils && yum-config-manager --enable epel 1>/dev/null && yum -y install python27 && yum -y remove python-devel && yum -y install python27-devel && curl -L https://bootstrap.pypa.io/get-pip.py > get-pip.py && python2.7 get-pip.py && yum -y install gcc gcc-c++
     provisioner:
       ansible_platform: 'amazon'
       ansible_distribution: 'Amazon'
@@ -75,11 +92,13 @@ platforms:
       require_ruby_for_busser: false
     verifier:
       ruby_bindir: '/opt/chef/embedded/bin'
+    file: path=/tmp state=directory mode=0777 recurse=yes
+
   - name: amazonlinux-2016.09
     driver_config:
-      image: librato/agent_amazon_2016.09
-      platform: centos
-      remove_images: true
+      image: amazonlinux:2016.09
+      platform: rhel
+      provision_command: sed -i'' 's/releasever=latest/# releasever=latest/' /etc/yum.conf && yum -y reinstall glibc-common &&  yum -y remove ca-certificates && yum -y install ca-certificates && yum -y update ca-certificates && yum -y update && yum -y --skip-broke groupinstall "Development Tools" && yum -y install epel-release yum-utils && yum-config-manager --enable epel 1>/dev/null && yum -y install python27 && yum -y remove python-devel && yum -y install python27-devel && curl -L https://bootstrap.pypa.io/get-pip.py > get-pip.py && python2.7 get-pip.py && yum -y install gcc gcc-c++
     provisioner:
       ansible_platform: 'amazon'
       ansible_distribution: 'Amazon'
@@ -88,11 +107,13 @@ platforms:
       require_ruby_for_busser: false
     verifier:
       ruby_bindir: '/opt/chef/embedded/bin'
+    file: path=/tmp state=directory mode=0777 recurse=yes
+
   - name: amazonlinux-2017.03
     driver_config:
-      image: librato/agent_amazon_2017.03
-      platform: centos
-      remove_images: true
+      image: amazonlinux:2017.03
+      platform: rhel
+      provision_command: sed -i'' 's/releasever=latest/# releasever=latest/' /etc/yum.conf && yum -y reinstall glibc-common &&  yum -y remove ca-certificates && yum -y install ca-certificates && yum -y update ca-certificates && yum -y update && yum -y --skip-broke groupinstall "Development Tools" && yum -y install epel-release yum-utils && yum-config-manager --enable epel 1>/dev/null && yum -y install python27 && yum -y remove python-devel && yum -y install python27-devel && curl -L https://bootstrap.pypa.io/get-pip.py > get-pip.py && python2.7 get-pip.py && yum -y install gcc gcc-c++
     provisioner:
       ansible_platform: 'amazon'
       ansible_distribution: 'Amazon'
@@ -101,6 +122,7 @@ platforms:
       require_ruby_for_busser: false
     verifier:
       ruby_bindir: '/opt/chef/embedded/bin'
+    file: path=/tmp state=directory mode=0777 recurse=yes
 
 suites:
   - name: default

--- a/README.md
+++ b/README.md
@@ -527,6 +527,8 @@ To use your own custom or upstream collectd plugin, simply have another module d
 * RHEL 7 / CentOS 7
 * Fedora 23
 * Amazon Linux 2016.03
+* Amazon Linux 2016.09
+* Amazon Linux 2017.03
 * Ubuntu 12.04
 * Ubuntu 14.04
 * Ubuntu 15.04

--- a/README.md
+++ b/README.md
@@ -413,6 +413,12 @@ To use your own custom or upstream collectd plugin, simply have another module d
 
   The repo base to use. Defaults to Librato's repo collection `librato-collectd`.
 
+- `librato_amazon_repo_base`
+
+  **Type**: string
+
+  The repo base to use for Amazon Linux. Defaults to Librato's repo collection `librato-amazonlinux-collectd`.
+
 - `librato_config_base`
 
   **Type**: string

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,9 +1,10 @@
 librato_email: ''
 librato_token: ''
 librato_repo_url: 'https://packagecloud.io/librato/'
-librato_repo_base: 'librato-collectd'
-librato_deb_version: '5.5.0-librato51.251'
-librato_rh_version: '5.5.0_librato51.251'
+librato_repo_base: 'librato-collectd-ci'
+librato_amazon_repo_base: 'librato-amazonlinux-collectd-ci'
+librato_deb_version: '5.7.1-librato1.416'
+librato_rh_version: '5.7.1_librato1.416'
 librato_config_base: '/opt/collectd/etc'
 librato_plugin_config_path: '/opt/collectd/etc/collectd.conf.d'
 librato_fqdn_lookup: true

--- a/tasks/agent.yml
+++ b/tasks/agent.yml
@@ -24,6 +24,17 @@
     - collectd
   when: ansible_distribution == 'Fedora'
 
+- name: Add hiredis to system path (RedHat/CentOS/Amazon)
+  become: true
+  shell: echo "/usr/local/lib" > "/etc/ld.so.conf.d/hiredis-x86_64.conf" && ldconfig -v
+  args:
+    creates: "/etc/ld.so.conf.d/hiredis-x86_64.conf"
+  notify:
+    - collectd
+  when:
+    - ansible_os_family == 'RedHat'
+    - ansible_distribution != 'Fedora'
+
 - name: setup_collectd_config
   template:
     src: collectd.conf.jinja

--- a/tasks/agent.yml
+++ b/tasks/agent.yml
@@ -26,7 +26,7 @@
 
 - name: Add hiredis to system path (RedHat/CentOS/Amazon)
   become: true
-  shell: echo "/usr/local/lib" > "/etc/ld.so.conf.d/hiredis-x86_64.conf" && ldconfig -v
+  shell: echo "/usr/local/lib" > "/etc/ld.so.conf.d/hiredis-x86_64.conf" && ldconfig
   args:
     creates: "/etc/ld.so.conf.d/hiredis-x86_64.conf"
   notify:

--- a/tasks/agent.yml
+++ b/tasks/agent.yml
@@ -35,6 +35,11 @@
     - ansible_os_family == 'RedHat'
     - ansible_distribution != 'Fedora'
 
+- name: Create tmp directory (Amazon)
+  file: path=/tmp state=directory mode=0777
+  when:
+    - ansible_os_family == 'RedHat'
+
 - name: setup_collectd_config
   template:
     src: collectd.conf.jinja

--- a/tasks/repo.yml
+++ b/tasks/repo.yml
@@ -67,10 +67,26 @@
     gpgcheck: no
   when: ansible_distribution == 'Fedora'
 
-- name: Create yum repo (Amazon Linux)
+- name: Create yum repo (Amazon Linux 2016.03)
   yum_repository:
     name: 'librato_{{ librato_repo_base }}'
     description: 'librato_{{ librato_repo_base }}'
-    baseurl: '{{ librato_repo_url }}librato-amazonlinux-collectd/el/6/$basearch'
+    baseurl: '{{ librato_repo_url }}{{librato_amazon_repo_base}}-2016-03/el/6/$basearch'
     gpgcheck: no
-  when: ansible_distribution == 'Amazon'
+  when: ansible_distribution == 'Amazon' and ansible_distribution_version == '2016.03'
+
+- name: Create yum repo (Amazon Linux 2016.09)
+  yum_repository:
+    name: 'librato_{{ librato_repo_base }}'
+    description: 'librato_{{ librato_repo_base }}'
+    baseurl: '{{ librato_repo_url }}{{librato_amazon_repo_base}}-2016-09/el/6/$basearch'
+    gpgcheck: no
+  when: ansible_distribution == 'Amazon' and ansible_distribution_version == '2016.09'
+
+- name: Create yum repo (Amazon Linux 2017.03)
+  yum_repository:
+    name: 'librato_{{ librato_repo_base }}'
+    description: 'librato_{{ librato_repo_base }}'
+    baseurl: '{{ librato_repo_url }}{{librato_amazon_repo_base}}-2017-03/el/6/$basearch'
+    gpgcheck: no
+  when: ansible_distribution == 'Amazon' and ansible_distribution_version == '2017.03'


### PR DESCRIPTION
Added Amazon Linux 2016.09 and 2017.03 platforms.  

Ticket: https://app.asana.com/0/40361156982972/343339806746944

Modified the kitchen framework configuration to use docker as main driver instead of vagrant (which doesn't provide amazon images, so it is forcing us to use EC2 instances). Testing of changes on Amazon Linux platforms uses the official docker images provided by Amazon except for 2016.03 version(not provided by Amazon). Amazon 2016.03 docker image is created by us and uploaded at librato/agent_amazon_2016.03. 

Removed EC2 testing for Amazon platform.