### PR TITLE
use the epel repo to install varnish-libs rpm

### DIFF
--- a/tasks/agent.yml
+++ b/tasks/agent.yml
@@ -10,6 +10,7 @@
   yum:
     name: collectd-core-{{ librato_rh_version }}
     state: present
+    enablerepo: epel
   notify:
     - collectd
   when:


### PR DESCRIPTION
Fixes this error:

```
Error: Package: collectd-core-5.7.1_librato1.413-0.x86_64 (librato_librato-collectd)
           Requires: varnish-libs
```