### PR TITLE
allow adding interface as a librato_enabled_plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ To include a plugin, set any variables you need for it, then add it to the `libr
 * `mysql`
 * `redis`
 * `haproxy`
+* `interface`
 
 ## Usage
 
@@ -155,6 +156,10 @@ To use your own custom or upstream collectd plugin, simply have another module d
 
     The default proxies to collect. Defaults to `server`, `frontend`, `backend`.
 
+### Plugin: `interface`
+
+  Interface has no configurable attributes.
+  
 ### Plugin: `jvm`
   - `librato_jvm_host`
 

--- a/templates/interface.conf.jinja
+++ b/templates/interface.conf.jinja
@@ -1,0 +1,5 @@
+LoadPlugin interface
+<Plugin "interface">
+	Interface "lo"
+	IgnoreSelected true
+</Plugin>


### PR DESCRIPTION
With this PR, adding `interface` to the `librato_enabled_plugins` array will help get network metrics.