### PR TITLE
add tags to be able to use --tags=librato

### DIFF
--- a/tasks/agent.yml
+++ b/tasks/agent.yml
@@ -5,6 +5,8 @@
   notify:
     - collectd
   when: ansible_os_family == 'Debian'
+  tags:
+    - librato
 
 - name: Install package (RedHat/CentOS/Amazon)
   yum:
@@ -15,6 +17,8 @@
   when:
     - ansible_os_family == 'RedHat'
     - ansible_distribution != 'Fedora'
+  tags:
+    - librato
 
 - name: Install package (Fedora)
   dnf:
@@ -23,6 +27,8 @@
   notify:
     - collectd
   when: ansible_distribution == 'Fedora'
+  tags:
+    - librato
 
 - name: setup_collectd_config
   template:
@@ -33,6 +39,8 @@
     mode: 0644
   notify:
     - collectd
+  tags:
+    - librato
 
 - name: setup_logging_plugin
   template:
@@ -43,6 +51,8 @@
     mode: 0644
   notify:
     - collectd
+  tags:
+    - librato
 
 - name: setup_librato_plugin
   template:
@@ -53,6 +63,8 @@
     mode: 0644
   notify:
     - collectd
+  tags:
+    - librato
 
 - name: Default plugins
   copy:
@@ -64,6 +76,8 @@
   notify:
     - collectd
   with_items: "{{ librato_default_plugins }}"
+  tags:
+    - librato
 
 - name: Additional enabled plugins
   template:
@@ -75,9 +89,13 @@
   notify:
     - collectd
   with_items: "{{ librato_enabled_plugins }}"
+  tags:
+    - librato
 
 - name: collectd_service
   service:
     name: collectd
     state: started
     enabled: yes
+  tags:
+    - librato

--- a/tasks/apache.yml
+++ b/tasks/apache.yml
@@ -7,3 +7,5 @@
     mode: 0644
   notify:
     - collectd
+  tags:
+    - librato

--- a/tasks/docker.yml
+++ b/tasks/docker.yml
@@ -7,3 +7,5 @@
     mode: 0644
   notify:
     - collectd
+  tags:
+    - librato

--- a/tasks/elasticsearch.yml
+++ b/tasks/elasticsearch.yml
@@ -7,3 +7,5 @@
     mode: 0644
   notify:
     - collectd
+  tags:
+    - librato

--- a/tasks/haproxy.yml
+++ b/tasks/haproxy.yml
@@ -7,3 +7,5 @@
     mode: 0644
   notify:
     - collectd
+  tags:
+    - librato

--- a/tasks/jvm.yml
+++ b/tasks/jvm.yml
@@ -7,3 +7,5 @@
     mode: 0644
   notify:
     - collectd
+  tags:
+    - librato

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,3 +1,8 @@
 ---
 - include: repo.yml tags=librato
+  tags:
+    - librato
+
 - include: agent.yml tags=librato
+  tags:
+    - librato

--- a/tasks/memcached.yml
+++ b/tasks/memcached.yml
@@ -7,3 +7,5 @@
     mode: 0644
   notify:
     - collectd
+  tags:
+    - librato

--- a/tasks/mongodb.yml
+++ b/tasks/mongodb.yml
@@ -7,3 +7,5 @@
     mode: 0644
   notify:
     - collectd
+  tags:
+    - librato

--- a/tasks/mysql.yml
+++ b/tasks/mysql.yml
@@ -7,3 +7,5 @@
     mode: 0644
   notify:
     - collectd
+  tags:
+    - librato

--- a/tasks/nginx.yml
+++ b/tasks/nginx.yml
@@ -7,3 +7,5 @@
     mode: 0644
   notify:
     - collectd
+  tags:
+    - librato

--- a/tasks/nginx_plus.yml
+++ b/tasks/nginx_plus.yml
@@ -7,3 +7,5 @@
     mode: 0644
   notify:
     - collectd
+  tags:
+    - librato

--- a/tasks/postgresql.yml
+++ b/tasks/postgresql.yml
@@ -7,3 +7,5 @@
     mode: 0644
   notify:
     - collectd
+  tags:
+    - librato

--- a/tasks/redis.yml
+++ b/tasks/redis.yml
@@ -7,3 +7,5 @@
     mode: 0644
   notify:
     - collectd
+  tags:
+    - librato

--- a/tasks/repo.yml
+++ b/tasks/repo.yml
@@ -5,6 +5,8 @@
   when:
     - ansible_os_family == 'RedHat'
     - ansible_distribution != 'Fedora'
+  tags:
+    - librato
 
 - name: Install gpg key
   apt_key:
@@ -12,18 +14,24 @@
     id: 418A7F2FB0E1E6E7EABF6FE8C2E73424D59097AB
     state: present
   when: ansible_os_family == 'Debian'
+  tags:
+    - librato
 
 - name: Install apt-transport-https
   apt:
     name: apt-transport-https
     state: present
   when: ansible_os_family == 'Debian'
+  tags:
+    - librato
 
 - name: Create apt repo
   apt_repository:
     repo: 'deb {{ librato_repo_url }}{{ librato_repo_base }}/{{ ansible_distribution|lower }}/ {{ ansible_distribution_release }} main'
     state: present
   when: ansible_os_family == 'Debian'
+  tags:
+    - librato
 
 - name: collectd_apt_pin
   copy:
@@ -33,6 +41,8 @@
     group: root
     mode: 0644
   when: ansible_os_family == 'Debian'
+  tags:
+    - librato
 
 - name: collectd-core_apt_pin
   copy:
@@ -42,11 +52,15 @@
     group: root
     mode: 0644
   when: ansible_os_family == 'Debian'
+  tags:
+    - librato
 
 - name: Run apt-get update
   apt:
     update_cache: yes
   when: ansible_os_family == 'Debian'
+  tags:
+    - librato
 
 - name: Create yum repo
   yum_repository:
@@ -58,6 +72,8 @@
     - ansible_os_family == 'RedHat'
     - ansible_distribution != 'Fedora'
     - ansible_distribution != 'Amazon'
+  tags:
+    - librato
 
 - name: Create yum repo (Fedora)
   yum_repository:
@@ -66,6 +82,8 @@
     baseurl: '{{ librato_repo_url }}{{ librato_repo_base }}/fedora/$releasever/$basearch'
     gpgcheck: no
   when: ansible_distribution == 'Fedora'
+  tags:
+    - librato
 
 - name: Create yum repo (Amazon Linux)
   yum_repository:
@@ -74,3 +92,5 @@
     baseurl: '{{ librato_repo_url }}librato-amazonlinux-collectd/el/6/$basearch'
     gpgcheck: no
   when: ansible_distribution == 'Amazon'
+  tags:
+    - librato

--- a/tasks/varnish.yml
+++ b/tasks/varnish.yml
@@ -7,3 +7,5 @@
     mode: 0644
   notify:
     - collectd
+  tags:
+    - librato

--- a/tasks/zookeeper.yml
+++ b/tasks/zookeeper.yml
@@ -7,3 +7,5 @@
     mode: 0644
   notify:
     - collectd
+  tags:
+    - librato


### PR DESCRIPTION
This PR allows using `--tags=librato`. This is useful to speed up testing different configurations.